### PR TITLE
[ADD] tailwind colors and font families

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -3,6 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			rel="stylesheet"
+			href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&family=Montserrat:wght@400;70&family=Poppins:wght@300;400;500;700&display=swap"
+		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2,6 +2,6 @@
 
 <style lang="postcss">
 	:global(html) {
-		background-color: theme(colors.gray.100);
+		background-color: theme(colors.black.100);
 	}
 </style>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,39 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 export default {
-	content: ['./src/**/*.{html,js,svelte,ts}'],
+	content: ['./src/**/*.{html,js,svelte}'],
 	theme: {
-		extend: {}
+		colors: {
+			black: {
+				50: '#fbfbfb',
+				100: '#f2f2f2',
+				200: '#ededed',
+				300: '#c0c0c0',
+				400: '#949494',
+				500: '#848080',
+				600: '#5d5d5d',
+				700: '#2e2e2e',
+				800: '#292929',
+				900: '#121212',
+				950: '#000000'
+			},
+			red: {
+				100: '#fce8e7'
+			},
+			white: '#ffffff'
+		},
+		extend: {
+			backgroundImage: {
+				'gradient-red': 'linear-gradient(81.79deg, #e51510 24.63%, #ff7370 91.16%)',
+				'gradient-black': 'linear-gradient(107.27deg, #646464 32.42%, #000000 114.61%)'
+			},
+			fontFamily: {
+				josefin: ['"Josefin Sans"', ...defaultTheme.fontFamily.sans],
+				montserrat: ['Montserrat', ...defaultTheme.fontFamily.sans],
+				poppins: ['Poppins', ...defaultTheme.fontFamily.sans]
+			}
+		}
 	},
 	plugins: []
 };


### PR DESCRIPTION
Add (extend) tailwind config to have colors and font families following figma design